### PR TITLE
Small typo fix.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Files can be edited on the [Github site](https://github.com/maban/christmas-reci
 
 Recipes are formatted in [Markdown](https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet).
 
-Jekyll generates the raw files into the <i>_sites</i> folder, so do no edit any of the files in here.
+Jekyll generates the raw files into the <i>_site</i> folder, so do no edit any of the files in here.
 
 ## Further Reading
 


### PR DESCRIPTION
Jekyll compiles the site into the _site folder, not _sites.
